### PR TITLE
:tada: Adding functionality that allows for sending metrics using asynchronous behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ dxtrack.configure(
     aws_secret_access_key='<aws-secret-access-key>',
     buffer_metrics=False,
     papertrail_hostport='logsN.papertrailapp.com:XXXXX',
+    use_async_requests=True|False
 )
 ```
 
@@ -60,6 +61,8 @@ The `run_id` is meant to be a unique identifier for a single run of the context.
 The `profile_name` is an optional argument that allows you to specify which aws set of credentials you would like to use that are present in your aws credentials file.
 
 If you have a papertrail account, you can add all metrics (at the .info level) and errors (at the .error) via the `papertrail_hostport` option..
+
+The `use_async_requests` option can be used to execute the requests from dxtrack to Kinesis asynchronously, **caution: experimental**. By default this functionality is disabled.
 
 You can also pass your credentials directly via the `aws_access_key_id` & `aws_secret_access_key options`. If specified these are preferred over the profile name.
 

--- a/dxtrack/decorators.py
+++ b/dxtrack/decorators.py
@@ -1,0 +1,18 @@
+import asyncio
+
+
+def fire_and_forget(f):
+    """
+
+    A function that can be used as a decorator to execute the function asynchronously.
+    https://stackoverflow.com/questions/37278647/fire-and-forget-python-async-await/37345564
+
+    :param f: The function f run as async.
+
+        :return: Whatever was returned from the function that was run.
+
+    """
+    def wrapped(*args, **kwargs):
+        return asyncio.get_event_loop().run_in_executor(None, f, *args, *kwargs)
+
+    return wrapped

--- a/dxtrack/dxtrack_impl.py
+++ b/dxtrack/dxtrack_impl.py
@@ -157,23 +157,25 @@ class DXTrack:
         )
         self._err_buffer = []
 
-    @fire_and_forget
-    def _send_metrics_async(self):
+    def _send_metrics(self):
+        if self.use_async_requests is True:
+            self._send_metrics_async()
+        else:
+            self._send_metrics_sync()
+
+    def __send_metrics(self):
         self._write_out(
             self._metric_buffer, test_output_metric_file,
             self._metric_fhose_name
         )
         self._metric_buffer = []
 
-    def _send_metrics(self):
-        if self.use_async_requests is True:
-            self._send_metrics_async()
-        else:
-            self._write_out(
-                self._metric_buffer, test_output_metric_file,
-                self._metric_fhose_name
-            )
-            self._metric_buffer = []
+    @fire_and_forget
+    def _send_metrics_async(self):
+        self.__send_metrics()
+
+    def _send_metrics_sync(self):
+        self.__send_metrics()
 
     def _write_out(self, arr_of_dict, fname, fhose_name):
         entries = [json.dumps(entry) for entry in arr_of_dict]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,65 @@
+import unittest
+from dxtrack import DXTrack
+import time
+
+
+def one_second_function(*args):
+    time.sleep(1)
+
+
+MAXIMUM_ASYNC_EXECUTION_TIME = 0.05
+
+
+class TestAsyncBehaviour(unittest.TestCase):
+    """
+
+    A test class that runs DXTrack in both synchronous and asynchronous mode. We override the function that would be
+    used to send metrics with a function that takes 1 second to execute. (Although this should probably be a mocked
+    version of the object).
+
+    To verify that the functionality is working as expected we send a metric via DXTrack that executes our sleep
+    function. If everything is as expected, when running in async mode there should be almost no delay to get to the
+    next line in the text.
+
+    """
+    def test_async_is_non_blocking(self):
+        dx = DXTrack()
+        dx.configure(
+            context="test_context_001",
+            stage="dev",
+            run_id="test_non_async_call_takes_no_time_to_return",
+            default_metadata={},
+            use_async_requests=True
+        )
+        #
+        #   Override our default write out function with our one that sleeps synchronously.
+        dx._write_out = one_second_function
+        #
+        #   Take a look at the time now, run our function, and check how long it took.
+        then = time.time()
+        dx.metric("a", 0)
+        now = time.time()
+        #
+        #   Check that the difference in time is no longer than our allotted maximum execution time for async functions.
+        assert now - then < MAXIMUM_ASYNC_EXECUTION_TIME
+
+    def test_sync_is_blocking(self):
+        dx = DXTrack()
+        dx.configure(
+            context="test_context_001",
+            stage="dev",
+            run_id="test_sync_call_takes_a_while_to_return",
+            default_metadata={},
+            use_async_requests=False
+        )
+        #
+        #   Override our default write out function with our one that sleeps synchronously.
+        dx._write_out = one_second_function
+        #
+        #   Take a look at the time now, run our function, and check how long it took.
+        then = time.time()
+        dx.metric("a", 0)
+        now = time.time()
+        #
+        #   Check that the difference in time is longer than our allotted maximum execution time for async functions.
+        assert now - then > MAXIMUM_ASYNC_EXECUTION_TIME


### PR DESCRIPTION
## Changes

- Editing `_send_metrics()` to check if we should call things async.
- Adding `__send_metrics()` with what was previously in `_send_metrics()`. It's now the actual function that handles sending metrics.
- Adding `_send_metrics_async()` & `_send_metrics_sync()` to call `__send_metrics()` in the correct manner.
- Adding the decorator `fire_and_forget()`.
- Adding tests to show the async functionality works as expected.

## Implications

- As we're running inside the asyncio event loop, it's probably that a halt message `Ctrl+C` would destroy anything running in that event loop (if it wasn't completed and the rest of the application exited immediately).
  - Although I don't know enough about asyncio to confirm.
